### PR TITLE
feat: hadcode verity superblock parameters and pin salt to repo refer…

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -47,6 +47,17 @@ models:
 
 At boot, the secure enclave does not mount the MWP disk directly. It first asks dm-verity to create a verified read-only mapper device using the trusted `rootHash` and `hashOffset`. It then mounts that verified mapper as EROFS.
 
+### dm-verity Parameter Pinning
+
+The verity mapping is always opened with `--no-superblock` and fully explicit parameters, so neither veritysetup nor the kernel ever parses on-disk metadata:
+
+- Hash algorithm, format version, and block sizes are fixed format constants.
+- The data size is `hashOffset / 4096` blocks, derived from the *attested* reference: the MWP data area is exactly the bytes preceding the hash area. This forecloses tampering with the on-disk data-size field to truncate the mapped device.
+- The hash tree starts at `hashOffset + 4096` (one hash block past the superblock slot).
+- The salt is `SHA256(<model identity>)` where the model identity is the packer's `name@revision` string, carried in the attested config as the required `repo` field. The consumer re-derives it; a wrong `repo` fails closed because nothing verifies against the attested root hash.
+
+The artifact still contains a dm-verity superblock at `hashOffset` (veritysetup writes one at format time), but consumers never read it: it is untrusted dead bytes occupying the first hash block.
+
 The mount path is:
 
 ```text
@@ -76,6 +87,7 @@ Example config:
 ```yaml
 models:
   - name: private-model
+    repo: "<hf_org>@<revision>"
     emwp: <rootHash>_<hashOffset>_<uuid>
     key-secret: PRIVATE_MODEL_KEY
 ```
@@ -157,6 +169,7 @@ Untrusted:
 Important consequences:
 
 - dm-verity integrity depends on the `rootHash` from *attested* config.
+- No artifact bytes are ever parsed before verification: every verity parameter is a pinned constant or derived from attested values (`rootHash`, `hashOffset`, `repo`), never read from the artifact.
 - EMWP confidentiality depends on the external EMWP master key.
 - EMWP authenticity is still the plaintext dm-verity check after decryption.
 - A malicious but correctly attested model artifact can still contain malicious model code or data.

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,7 +3,9 @@
 package modelwrap_test
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -97,9 +99,11 @@ func TestEMWPRoundTripIntegration(t *testing.T) {
 	}
 	t.Cleanup(func() { unwrap.CloseCrypt(cryptName) })
 
+	// Salt re-derived from the attested model identity; the artifact's
+	// superblock is never read.
 	verityName := "modelwrap-it-verity"
-	if err := unwrap.OpenVerity("/dev/mapper/"+cryptName, verityName, ref.RootHash, ref.HashOffset); err != nil {
-		t.Fatalf("opening dm-verity: %v", err)
+	if err := unwrap.OpenVerity("/dev/mapper/"+cryptName, verityName, ref.RootHash, ref.HashOffset, modelwrap.VeritySalt(integrationModel)); err != nil {
+		t.Fatalf("opening dm-verity via derived salt: %v", err)
 	}
 	t.Cleanup(func() { unwrap.CloseVerity(verityName) })
 
@@ -231,7 +235,7 @@ func TestEMWPGoEncryptKernelDecrypt(t *testing.T) {
 	if _, err := io.ReadFull(dev, got); err != nil {
 		t.Fatalf("reading kernel-decrypted device: %v", err)
 	}
-	if !bytesEqual(got, plain) {
+	if !bytes.Equal(got, plain) {
 		t.Fatalf("kernel dm-crypt decryption does not match the original MWP plaintext "+
 			"(first diff at byte %d): Go ciphertext is not dm-crypt compatible", firstDiffIdx(got, plain))
 	}
@@ -239,8 +243,123 @@ func TestEMWPGoEncryptKernelDecrypt(t *testing.T) {
 	// Independent integrity check, in userspace so it needs no dm-verity
 	// kernel target: the kernel-decrypted plaintext must satisfy the attested
 	// root hash.
-	if err := wrap.VerifyMWP("/dev/mapper/"+cryptName, filepath.Join(work, "output", "testmodel", "v1.info")); err != nil {
+	if err := wrap.VerifyMWP("/dev/mapper/"+cryptName, filepath.Join(work, "output", "testmodel", "v1.info"), "testmodel@v1"); err != nil {
 		t.Fatalf("veritysetup verify over kernel-decrypted plaintext: %v", err)
+	}
+}
+
+// TestMWPSuperblockTamperIntegration demonstrates the superblock
+// truncation issue and verifies the --no-superblock open path closes it.
+// It packs a local directory as plaintext MWP, shrinks the superblock's
+// data_blocks field by one, and checks that:
+//
+//  1. a legacy superblock-trusting open (plain --hash-offset) accepts the
+//     tampered artifact and maps a silently truncated device;
+//  2. the attested-identity open (derived salt, superblock never read)
+//     opens the full, untruncated device despite the tampering.
+//
+// Requires the same privileged Linux environment as the round-trip test.
+func TestMWPSuperblockTamperIntegration(t *testing.T) {
+	if os.Getenv("TINFOIL_MODELWRAP_INTEGRATION") != "1" {
+		t.Skip("set TINFOIL_MODELWRAP_INTEGRATION=1 to run")
+	}
+
+	work := t.TempDir()
+	modelDir := filepath.Join(work, "model")
+	if err := os.MkdirAll(modelDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A payload large enough for a few data blocks.
+	payload := bytes.Repeat([]byte("tinfoil superblock tamper test\n"), 8192)
+	for _, name := range []string{"weights.bin", "config.json"} {
+		if err := os.WriteFile(filepath.Join(modelDir, name), payload, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rawRef, err := wrap.Pack(wrap.Options{
+		Model:     "tamper-test",
+		ModelDir:  modelDir,
+		CacheDir:  filepath.Join(work, "cache"),
+		OutputDir: filepath.Join(work, "output"),
+		Verify:    true,
+	})
+	if err != nil {
+		t.Fatalf("packing MWP: %v", err)
+	}
+	ref, err := modelwrap.ParseRef(rawRef)
+	if err != nil {
+		t.Fatalf("parsing packed ref %q: %v", rawRef, err)
+	}
+	revision, err := modelwrap.HashDir(modelDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := "tamper-test@" + revision
+	mwpFile := filepath.Join(work, "output", "tamper-test", revision+".mpk")
+	hashOffset, err := ref.HashOffsetBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shrink data_blocks (u64 at superblock offset 72) by one block.
+	f, err := os.OpenFile(mwpFile, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	blocksField := make([]byte, 8)
+	if _, err := f.ReadAt(blocksField, int64(hashOffset)+72); err != nil {
+		t.Fatal(err)
+	}
+	dataBlocks := binary.LittleEndian.Uint64(blocksField)
+	binary.LittleEndian.PutUint64(blocksField, dataBlocks-1)
+	if _, err := f.WriteAt(blocksField, int64(hashOffset)+72); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Legacy superblock-trusting open accepts the tampered artifact.
+	legacyName := "modelwrap-it-tamper-legacy"
+	legacy := exec.Command("veritysetup", "open", mwpFile, legacyName, mwpFile, ref.RootHash, "--hash-offset="+ref.HashOffset)
+	legacy.Stdout, legacy.Stderr = os.Stdout, os.Stderr
+	if err := legacy.Run(); err != nil {
+		t.Fatalf("expected legacy superblock-trusting open to accept the truncated artifact, got: %v", err)
+	}
+	sectors, err := exec.Command("blockdev", "--getsz", "/dev/mapper/"+legacyName).Output()
+	unwrap.CloseVerity(legacyName)
+	if err != nil {
+		t.Fatalf("reading truncated mapper size: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(sectors)), fmt.Sprint((dataBlocks-1)*8); got != want {
+		t.Fatalf("legacy mapper size = %s sectors, want truncated %s", got, want)
+	}
+	t.Logf("legacy open accepted tampered artifact with truncated size %d blocks", dataBlocks-1)
+
+	// 2. Attested-identity open never reads the superblock and maps the full device.
+	derivedName := "modelwrap-it-tamper-derived"
+	if err := unwrap.OpenVerity(mwpFile, derivedName, ref.RootHash, ref.HashOffset, modelwrap.VeritySalt(model)); err != nil {
+		t.Fatalf("derived-salt open failed on tampered superblock: %v", err)
+	}
+	t.Cleanup(func() { unwrap.CloseVerity(derivedName) })
+	sectors, err = exec.Command("blockdev", "--getsz", "/dev/mapper/"+derivedName).Output()
+	if err != nil {
+		t.Fatalf("reading derived mapper size: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(sectors)), fmt.Sprint(dataBlocks*8); got != want {
+		t.Fatalf("derived mapper size = %s sectors, want full %s", got, want)
+	}
+
+	mountPoint := filepath.Join(work, "mnt")
+	if err := unwrap.Mount("/dev/mapper/"+derivedName, mountPoint); err != nil {
+		t.Fatalf("mounting verified EROFS: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Command("umount", mountPoint).Run() })
+	got, err := os.ReadFile(filepath.Join(mountPoint, "weights.bin"))
+	if err != nil {
+		t.Fatalf("reading mounted file: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("mounted file content mismatch")
 	}
 }
 
@@ -251,16 +370,4 @@ func firstDiffIdx(a, b []byte) int {
 		}
 	}
 	return min(len(a), len(b))
-}
-
-func bytesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/modelwrap.go
+++ b/modelwrap.go
@@ -12,19 +12,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
 	"golang.org/x/mod/sumdb/dirhash"
-)
-
-// dm-verity format parameters. These are passed explicitly to veritysetup
-// so tool default changes never silently alter the artifact format.
-const (
-	VerityFormat        = 1
-	VerityHashAlgorithm = "sha256"
-	VerityDataBlockSize = 4096
-	VerityHashBlockSize = 4096
 )
 
 // EMWP dm-crypt parameters.
@@ -94,6 +86,15 @@ func (r *ArtifactRef) String() string {
 // EMWP key derivation, binding the derived key to one specific artifact.
 func (r *ArtifactRef) ArtifactID() string {
 	return r.RootHash + "_" + r.UUID
+}
+
+// HashOffsetBytes parses the reference's hash offset field.
+func (r *ArtifactRef) HashOffsetBytes() (uint64, error) {
+	offset, err := strconv.ParseUint(r.HashOffset, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid hash offset %q: %w", r.HashOffset, err)
+	}
+	return offset, nil
 }
 
 // DeriveKey derives the per-artifact dm-crypt key from the EMWP master key

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -35,13 +35,14 @@ docker run --rm \
   "${GO_IMAGE}" \
   bash -c 'export PATH="${PATH}:/usr/local/go/bin" && cd /src && GOOS=linux go test -tags=integration -c . -o /work/modelwrap.test'
 
-# Protocol round trip: pack with wrap, consume with unwrap.
+# Protocol round trip plus superblock tamper regression: pack with wrap,
+# consume with unwrap, reject/neutralize tampered superblocks.
 docker run --rm --privileged \
   -v "${WORK_DIR}/modelwrap.test:/tmp/modelwrap.test:ro" \
   -e TINFOIL_MODELWRAP_INTEGRATION=1 \
   --entrypoint /tmp/modelwrap.test \
   "${IMAGE}" \
-  -test.run TestEMWPRoundTripIntegration -test.v
+  -test.run 'TestEMWPRoundTripIntegration|TestEMWPGoEncryptKernelDecrypt|TestMWPSuperblockTamperIntegration' -test.v
 
 # CLI smoke test: the user-facing entrypoint with volumes and key file.
 # Packing is userspace-only, so it runs unprivileged.

--- a/unwrap/unwrap.go
+++ b/unwrap/unwrap.go
@@ -65,7 +65,7 @@ func OpenVerity(device, name, rootHash, hashOffset string, salt []byte) error {
 	}
 	params, err := modelwrap.VerityParamsForArtifact(offset, salt)
 	if err != nil {
-		return err
+		return fmt.Errorf("deriving verity params: %w", err)
 	}
 
 	args := append([]string{

--- a/unwrap/unwrap.go
+++ b/unwrap/unwrap.go
@@ -50,18 +50,32 @@ func CloseCrypt(name string) {
 }
 
 // OpenVerity opens a dm-verity mapping over a device that contains a
-// filesystem followed by its hash tree at hashOffset. The remaining
-// verity parameters come from the superblock, which is authenticated by
-// the root hash.
-func OpenVerity(device, name, rootHash, hashOffset string) error {
-	cmd := exec.Command(
-		"veritysetup", "open",
+// filesystem followed by its hash tree at hashOffset.
+//
+// The mapping is always opened with --no-superblock and fully explicit,
+// pinned format parameters, so veritysetup and the kernel never parse
+// any on-disk metadata. The data size is derived from the attested
+// hashOffset, and the salt (32 bytes) is re-derived from the attested
+// model identity via modelwrap.VeritySalt. A wrong salt fails closed:
+// nothing can verify against the attested root hash.
+func OpenVerity(device, name, rootHash, hashOffset string, salt []byte) error {
+	offset, err := strconv.ParseUint(hashOffset, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid hash offset %q: %w", hashOffset, err)
+	}
+	params, err := modelwrap.VerityParamsForArtifact(offset, salt)
+	if err != nil {
+		return err
+	}
+
+	args := append([]string{
+		"open",
 		device,
 		name,
 		device,
 		rootHash,
-		"--hash-offset="+hashOffset,
-	)
+	}, params.VeritysetupArgs()...)
+	cmd := exec.Command("veritysetup", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/verity.go
+++ b/verity.go
@@ -1,0 +1,73 @@
+package modelwrap
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// dm-verity format parameters. These are passed explicitly to veritysetup
+// so tool default changes never silently alter the artifact format, and
+// consumers never read them from the artifact.
+const (
+	VerityFormat        = 1
+	VerityHashAlgorithm = "sha256"
+	VerityDataBlockSize = 4096
+	VerityHashBlockSize = 4096
+	VeritySaltBytes     = 32 // a SHA-256 digest
+
+	maxHashOffset = 1 << 62 // fits int64 with room for the tree offset
+)
+
+// VeritySalt returns the deterministic dm-verity salt for a model
+// identity string (name@revision): the SHA-256 of the identity. The
+// packer uses this when formatting; the consumer re-derives it from the
+// attested model identity, so no on-disk metadata is ever consulted.
+func VeritySalt(model string) []byte {
+	sum := sha256.Sum256([]byte(model))
+	return sum[:]
+}
+
+// VerityParams are the fully explicit parameters for opening an MWP hash
+// tree with `veritysetup --no-superblock`, so that no unverified on-disk
+// metadata is ever parsed by the dm-verity stack.
+type VerityParams struct {
+	Salt           []byte
+	DataBlocks     uint64
+	HashTreeOffset uint64 // byte offset of the first hash tree block
+}
+
+// VeritysetupArgs returns the explicit veritysetup arguments pinning
+// every format parameter for a --no-superblock open or verify.
+func (p *VerityParams) VeritysetupArgs() []string {
+	return []string{
+		"--no-superblock",
+		fmt.Sprintf("--format=%d", VerityFormat),
+		"--hash=" + VerityHashAlgorithm,
+		fmt.Sprintf("--data-block-size=%d", VerityDataBlockSize),
+		fmt.Sprintf("--hash-block-size=%d", VerityHashBlockSize),
+		fmt.Sprintf("--data-blocks=%d", p.DataBlocks),
+		fmt.Sprintf("--hash-offset=%d", p.HashTreeOffset),
+		"--salt=" + hex.EncodeToString(p.Salt),
+	}
+}
+
+// VerityParamsForArtifact derives explicit dm-verity parameters from the
+// attested hash offset and the salt. In the MWP layout the data area is
+// exactly the hashOffset bytes preceding the hash area, so the data size
+// is attested rather than read from the artifact, and the hash tree
+// begins one hash block past hashOffset (the slot occupied by the
+// untrusted, ignored superblock the packer writes there).
+func VerityParamsForArtifact(hashOffset uint64, salt []byte) (*VerityParams, error) {
+	if len(salt) != VeritySaltBytes {
+		return nil, fmt.Errorf("verity salt is %d bytes, want %d", len(salt), VeritySaltBytes)
+	}
+	if hashOffset == 0 || hashOffset%VerityDataBlockSize != 0 || hashOffset > maxHashOffset {
+		return nil, fmt.Errorf("hash offset %d is not a positive multiple of %d", hashOffset, VerityDataBlockSize)
+	}
+	return &VerityParams{
+		Salt:           salt,
+		DataBlocks:     hashOffset / VerityDataBlockSize,
+		HashTreeOffset: hashOffset + VerityHashBlockSize,
+	}, nil
+}

--- a/verity.go
+++ b/verity.go
@@ -62,8 +62,11 @@ func VerityParamsForArtifact(hashOffset uint64, salt []byte) (*VerityParams, err
 	if len(salt) != VeritySaltBytes {
 		return nil, fmt.Errorf("verity salt is %d bytes, want %d", len(salt), VeritySaltBytes)
 	}
-	if hashOffset == 0 || hashOffset%VerityDataBlockSize != 0 || hashOffset > maxHashOffset {
+	if hashOffset == 0 || hashOffset%VerityDataBlockSize != 0 {
 		return nil, fmt.Errorf("hash offset %d is not a positive multiple of %d", hashOffset, VerityDataBlockSize)
+	}
+	if hashOffset > maxHashOffset {
+		return nil, fmt.Errorf("hash offset %d exceeds maximum %d", hashOffset, uint64(maxHashOffset))
 	}
 	return &VerityParams{
 		Salt:           salt,

--- a/verity_test.go
+++ b/verity_test.go
@@ -1,6 +1,7 @@
 package modelwrap
 
 import (
+	"encoding/hex"
 	"strings"
 	"testing"
 )
@@ -40,6 +41,7 @@ func TestVerityParamsForArtifact(t *testing.T) {
 		"--hash-block-size=4096",
 		"--data-blocks=10",
 		"--hash-offset=45056",
+		"--salt=" + hex.EncodeToString(salt),
 	} {
 		if !strings.Contains(args, want) {
 			t.Errorf("veritysetup args %q missing %q", args, want)

--- a/verity_test.go
+++ b/verity_test.go
@@ -1,0 +1,59 @@
+package modelwrap
+
+import (
+	"strings"
+	"testing"
+)
+
+const testHashOffset = uint64(40960) // 10 data blocks
+
+func TestVerityParamsForArtifact(t *testing.T) {
+	salt := VeritySalt("org/model@revision")
+
+	if _, err := VerityParamsForArtifact(testHashOffset, salt[:16]); err == nil {
+		t.Error("short salt was accepted")
+	}
+	if _, err := VerityParamsForArtifact(testHashOffset+1, salt); err == nil {
+		t.Error("unaligned hash offset was accepted")
+	}
+	if _, err := VerityParamsForArtifact(0, salt); err == nil {
+		t.Error("zero hash offset was accepted")
+	}
+
+	params, err := VerityParamsForArtifact(testHashOffset, salt)
+	if err != nil {
+		t.Fatalf("deriving params: %v", err)
+	}
+	if params.DataBlocks != testHashOffset/VerityDataBlockSize {
+		t.Fatalf("data blocks = %d, want %d", params.DataBlocks, testHashOffset/VerityDataBlockSize)
+	}
+	if params.HashTreeOffset != testHashOffset+VerityHashBlockSize {
+		t.Fatalf("hash tree offset = %d, want %d", params.HashTreeOffset, testHashOffset+VerityHashBlockSize)
+	}
+
+	args := strings.Join(params.VeritysetupArgs(), " ")
+	for _, want := range []string{
+		"--no-superblock",
+		"--format=1",
+		"--hash=sha256",
+		"--data-block-size=4096",
+		"--hash-block-size=4096",
+		"--data-blocks=10",
+		"--hash-offset=45056",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("veritysetup args %q missing %q", args, want)
+		}
+	}
+}
+
+func TestVeritySaltDeterministic(t *testing.T) {
+	a := VeritySalt("org/model@revision")
+	b := VeritySalt("org/model@revision")
+	if string(a) != string(b) || len(a) != VeritySaltBytes {
+		t.Fatal("salt derivation is not deterministic 32 bytes")
+	}
+	if string(a) == string(VeritySalt("org/model@other")) {
+		t.Fatal("different identities produced the same salt")
+	}
+}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -7,7 +7,6 @@
 package wrap
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -88,7 +87,7 @@ func Pack(opts Options) (string, error) {
 	}
 
 	if opts.Verify {
-		if err := VerifyMWP(mwpFile, infoFile); err != nil {
+		if err := VerifyMWP(mwpFile, infoFile, model); err != nil {
 			return "", err
 		}
 	} else {
@@ -135,7 +134,7 @@ func Pack(opts Options) (string, error) {
 	}
 
 	if opts.Verify {
-		if err := VerifyEMWP(emwpFile, emwpInfoFile, masterKey); err != nil {
+		if err := VerifyEMWP(emwpFile, emwpInfoFile, masterKey, model); err != nil {
 			return "", err
 		}
 	}
@@ -271,8 +270,14 @@ func formatVerity(model, mwpFile, infoFile string) error {
 		return err
 	}
 	offset := (fi.Size() + 4095) / 4096 * 4096
+	if fi.Size() != offset {
+		// The strict consumer derives the data size from the hash offset
+		// (data area == hashOffset bytes), which requires block alignment.
+		// EROFS images are always 4K-aligned, so this should never fire.
+		return fmt.Errorf("EROFS image size %d is not a multiple of %d", fi.Size(), modelwrap.VerityDataBlockSize)
+	}
 	verityUUID := modelwrap.UUIDv5URL(model + "-inner")
-	salt := sha256.Sum256([]byte(model))
+	salt := modelwrap.VeritySalt(model)
 
 	fmt.Printf("Running veritysetup on %s\n", mwpFile)
 	err = run(exec.Command(
@@ -281,7 +286,7 @@ func formatVerity(model, mwpFile, infoFile string) error {
 		"--hash="+modelwrap.VerityHashAlgorithm,
 		fmt.Sprintf("--data-block-size=%d", modelwrap.VerityDataBlockSize),
 		fmt.Sprintf("--hash-block-size=%d", modelwrap.VerityHashBlockSize),
-		"--salt="+hex.EncodeToString(salt[:]),
+		"--salt="+hex.EncodeToString(salt),
 		"--uuid="+verityUUID,
 		fmt.Sprintf("--hash-offset=%d", offset),
 		"--root-hash-file="+infoFile,
@@ -376,8 +381,10 @@ func encryptPayload(imgFile, mwpFile string, dmKey []byte) error {
 }
 
 // VerifyMWP runs an offline dm-verity verification of an MWP artifact
-// against its info file.
-func VerifyMWP(mwpFile, infoFile string) error {
+// against its info file, through the same strict path consumers use:
+// veritysetup with --no-superblock and fully explicit parameters, with
+// the salt derived from the model identity.
+func VerifyMWP(mwpFile, infoFile, model string) error {
 	ref, err := parseInfoFile(infoFile)
 	if err != nil {
 		return err
@@ -386,19 +393,23 @@ func VerifyMWP(mwpFile, infoFile string) error {
 		return fmt.Errorf("MWP artifact not found: %s", mwpFile)
 	}
 
+	offset, err := ref.HashOffsetBytes()
+	if err != nil {
+		return err
+	}
+	params, err := modelwrap.VerityParamsForArtifact(offset, modelwrap.VeritySalt(model))
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("Verifying dm-verity artifact %s\n", mwpFile)
-	err = run(exec.Command(
-		"veritysetup",
-		fmt.Sprintf("--format=%d", modelwrap.VerityFormat),
-		"--hash="+modelwrap.VerityHashAlgorithm,
-		fmt.Sprintf("--data-block-size=%d", modelwrap.VerityDataBlockSize),
-		fmt.Sprintf("--hash-block-size=%d", modelwrap.VerityHashBlockSize),
-		"--hash-offset="+ref.HashOffset,
+	args := append([]string{
 		"verify",
 		mwpFile, // data device
 		mwpFile, // hash device
 		ref.RootHash,
-	))
+	}, params.VeritysetupArgs()...)
+	err = run(exec.Command("veritysetup", args...))
 	if err != nil {
 		return err
 	}
@@ -408,7 +419,7 @@ func VerifyMWP(mwpFile, infoFile string) error {
 
 // VerifyEMWP decrypts an EMWP artifact's payload partition in userspace and
 // verifies the inner dm-verity tree of the recovered MWP plaintext.
-func VerifyEMWP(emwpFile, infoFile string, masterKey []byte) error {
+func VerifyEMWP(emwpFile, infoFile string, masterKey []byte, model string) error {
 	ref, err := parseInfoFile(infoFile)
 	if err != nil {
 		return err
@@ -429,7 +440,7 @@ func VerifyEMWP(emwpFile, infoFile string, masterKey []byte) error {
 	if err := decryptPayload(emwpFile, plainFile, fi.Size(), dmKey); err != nil {
 		return err
 	}
-	return VerifyMWP(plainFile, infoFile)
+	return VerifyMWP(plainFile, infoFile, model)
 }
 
 // decryptPayload streams the decrypted MWP plaintext of an EMWP image's


### PR DESCRIPTION
…ence

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcode dm-verity parameters and derive the salt from the attested `repo` (name@revision), always opening with `--no-superblock` to avoid parsing untrusted metadata and to prevent superblock-based truncation.

- **Bug Fixes**
  - Always open/verify with `--no-superblock` and pinned params: format 1, `sha256`, 4K blocks, `data-blocks = hashOffset/4096`, `hash-offset = hashOffset + 4096`, `salt = SHA256(name@revision)`. No on-disk metadata is read before verification.
  - Close the superblock truncation issue; new integration test shows legacy open truncates while the derived-salt path maps full size.
  - Added `modelwrap.VeritySalt`, `VerityParamsForArtifact` (+ `VeritysetupArgs`), `ArtifactRef.HashOffsetBytes`, and unit tests; updated `unwrap.OpenVerity` to accept `salt []byte`, derive/validate params with clearer overflow errors, and wrap failures with context.
  - `wrap.VerifyMWP`/`wrap.VerifyEMWP` now verify via the strict path using the model identity; tests pin `--salt`; `SPEC.md` documents parameter pinning and the `repo` requirement.

- **Migration**
  - Attested config must include `repo: "<org>@<revision>"`; consumers re-derive the salt from this.
  - API changes: `unwrap.OpenVerity(device, name, rootHash, hashOffset, salt []byte)`, `wrap.VerifyMWP(mwpFile, infoFile, model)`, `wrap.VerifyEMWP(emwpFile, infoFile, masterKey, model)`.
  - Packer now enforces 4K alignment of the EROFS image (fails if not aligned).

<sup>Written for commit 380d40377dee56ce7e6cb1b02f669cb3dd8748d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/modelwrap/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

