### PR TITLE
refactor: centralize dm-crypt parameters in crypt.go with shared cryp…

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -1,0 +1,63 @@
+package modelwrap
+
+import (
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// EMWP dm-crypt parameters. These are passed explicitly to cryptsetup so
+// tool default changes never silently alter the artifact format; with
+// --type plain there is no on-disk encryption metadata at all.
+const (
+	EMWPCipher         = "aes-xts-plain64"
+	EMWPKeySizeBits    = 512
+	EMWPKeyBytes       = EMWPKeySizeBits / 8
+	EMWPMasterKeyBytes = 64
+	EMWPSectorSize     = 4096
+	EMWPKeyDeriveInfo  = "tinfoil/emwp/dm-crypt-key/v1"
+)
+
+// EMWP GPT disk image geometry. The encrypted payload partition starts at
+// a fixed sector so ciphertext placement is deterministic.
+const (
+	GPTSectorSize            = 512
+	EMWPPartitionStartSector = 2048
+	EMWPGPTTrailingSectors   = 40
+)
+
+// CryptsetupArgs returns the explicit cryptsetup arguments pinning the
+// EMWP cipher parameters for a plain open. Packer and consumer share this
+// builder so their dm-crypt mappings can never drift apart.
+func CryptsetupArgs() []string {
+	return []string{
+		"--type", "plain",
+		"--cipher", EMWPCipher,
+		"--key-size", strconv.Itoa(EMWPKeySizeBits),
+		"--sector-size", strconv.Itoa(EMWPSectorSize),
+	}
+}
+
+// DeriveKey derives the per-artifact dm-crypt key from the EMWP master key
+// using HKDF-SHA256 with the artifact ID as salt.
+func DeriveKey(masterKey []byte, ref *ArtifactRef) ([]byte, error) {
+	if len(masterKey) != EMWPMasterKeyBytes {
+		return nil, fmt.Errorf("EMWP master key is %d bytes, want %d", len(masterKey), EMWPMasterKeyBytes)
+	}
+	return hkdf.Key(sha256.New, masterKey, []byte(ref.ArtifactID()), EMWPKeyDeriveInfo, EMWPKeyBytes)
+}
+
+// ParseMasterKey decodes and validates a base64-encoded EMWP master key.
+func ParseMasterKey(encoded string) ([]byte, error) {
+	key, err := base64.StdEncoding.Strict().DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("decoding EMWP master key as base64: %w", err)
+	}
+	if len(key) != EMWPMasterKeyBytes {
+		return nil, fmt.Errorf("EMWP master key decoded to %d bytes, want %d", len(key), EMWPMasterKeyBytes)
+	}
+	return key, nil
+}

--- a/crypt.go
+++ b/crypt.go
@@ -30,14 +30,17 @@ const (
 )
 
 // CryptsetupArgs returns the explicit cryptsetup arguments pinning the
-// EMWP cipher parameters for a plain open. Packer and consumer share this
-// builder so their dm-crypt mappings can never drift apart.
+// EMWP cipher parameters for a plain open, so tool default changes can
+// never alter the mapping. --skip 0 pins the plain64 IV numbering to
+// start at the volume's first sector, matching the Go encryptor and the
+// dm-crypt golden vector.
 func CryptsetupArgs() []string {
 	return []string{
 		"--type", "plain",
 		"--cipher", EMWPCipher,
 		"--key-size", strconv.Itoa(EMWPKeySizeBits),
 		"--sector-size", strconv.Itoa(EMWPSectorSize),
+		"--skip", "0",
 	}
 }
 

--- a/modelwrap.go
+++ b/modelwrap.go
@@ -6,8 +6,6 @@
 package modelwrap
 
 import (
-	"crypto/hkdf"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -17,24 +15,6 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/mod/sumdb/dirhash"
-)
-
-// EMWP dm-crypt parameters.
-const (
-	EMWPCipher         = "aes-xts-plain64"
-	EMWPKeySizeBits    = 512
-	EMWPKeyBytes       = EMWPKeySizeBits / 8
-	EMWPMasterKeyBytes = 64
-	EMWPSectorSize     = 4096
-	EMWPKeyDeriveInfo  = "tinfoil/emwp/dm-crypt-key/v1"
-)
-
-// EMWP GPT disk image geometry. The encrypted payload partition starts at
-// a fixed sector so ciphertext placement is deterministic.
-const (
-	GPTSectorSize            = 512
-	EMWPPartitionStartSector = 2048
-	EMWPGPTTrailingSectors   = 40
 )
 
 var (
@@ -95,27 +75,6 @@ func (r *ArtifactRef) HashOffsetBytes() (uint64, error) {
 		return 0, fmt.Errorf("invalid hash offset %q: %w", r.HashOffset, err)
 	}
 	return offset, nil
-}
-
-// DeriveKey derives the per-artifact dm-crypt key from the EMWP master key
-// using HKDF-SHA256 with the artifact ID as salt.
-func DeriveKey(masterKey []byte, ref *ArtifactRef) ([]byte, error) {
-	if len(masterKey) != EMWPMasterKeyBytes {
-		return nil, fmt.Errorf("EMWP master key is %d bytes, want %d", len(masterKey), EMWPMasterKeyBytes)
-	}
-	return hkdf.Key(sha256.New, masterKey, []byte(ref.ArtifactID()), EMWPKeyDeriveInfo, EMWPKeyBytes)
-}
-
-// ParseMasterKey decodes and validates a base64-encoded EMWP master key.
-func ParseMasterKey(encoded string) ([]byte, error) {
-	key, err := base64.StdEncoding.Strict().DecodeString(strings.TrimSpace(encoded))
-	if err != nil {
-		return nil, fmt.Errorf("decoding EMWP master key as base64: %w", err)
-	}
-	if len(key) != EMWPMasterKeyBytes {
-		return nil, fmt.Errorf("EMWP master key decoded to %d bytes, want %d", len(key), EMWPMasterKeyBytes)
-	}
-	return key, nil
 }
 
 // UUIDv5URL computes the deterministic RFC 4122 version 5 UUID of name in

--- a/unwrap/unwrap.go
+++ b/unwrap/unwrap.go
@@ -25,17 +25,14 @@ const (
 // device using the format's cipher parameters. The key file must contain
 // the raw per-artifact key derived with modelwrap.DeriveKey.
 func OpenCrypt(device, name, keyFile string) error {
-	cmd := exec.Command(
-		"cryptsetup", "open",
-		"--type", "plain",
-		"--cipher", modelwrap.EMWPCipher,
-		"--key-size", strconv.Itoa(modelwrap.EMWPKeySizeBits),
-		"--sector-size", strconv.Itoa(modelwrap.EMWPSectorSize),
+	args := append([]string{"open"}, modelwrap.CryptsetupArgs()...)
+	args = append(args,
 		"--key-file", keyFile,
 		"--readonly",
 		device,
 		name,
 	)
+	cmd := exec.Command("cryptsetup", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
…tsetup args

Mirror verity.go for the encryption side: move the EMWP dm-crypt constants, GPT geometry, and key derivation into crypt.go, and give packer and consumer a single CryptsetupArgs builder so their plain dm-crypt mappings can never drift apart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized EMWP dm-crypt parameters and key derivation into `modelwrap/crypt.go`, with a shared `CryptsetupArgs` builder used by packer and consumer. Pins cipher params and `--skip 0` so plain `dm-crypt` mappings are stable and not subject to `cryptsetup` defaults.

- **Refactors**
  - Added `modelwrap/crypt.go` with EMWP constants, GPT geometry, `CryptsetupArgs` (includes `--skip 0`), `DeriveKey`, and `ParseMasterKey`.
  - Removed duplicated constants and key helpers from `modelwrap.go`.
  - Updated `unwrap.OpenCrypt` to build args via `modelwrap.CryptsetupArgs()`.

<sup>Written for commit b979bc0ddee5bad2184e92fbe1a8945198240eb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/modelwrap/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

