### PR TITLE
feat: add model artifact deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ matching image digest.
 modelwrap mistralai/Ministral-3-3B-Instruct-2512@cfcb068fa7c44114cf77a462357c6cdcd2c304b4
 ```
 
+Delete the generated artifacts and downloaded cache for one pinned revision:
+
+```sh
+modelwrap --delete mistralai/Ministral-3-3B-Instruct-2512@cfcb068fa7c44114cf77a462357c6cdcd2c304b4
+```
+
 To pack and encrypt a local/private model directory:
 
 ```bash

--- a/cmd/modelwrap/launcher.go
+++ b/cmd/modelwrap/launcher.go
@@ -106,6 +106,9 @@ func dockerRunArgs(opts cliOptions) ([]string, error) {
 
 	args = append(args, opts.image)
 
+	if opts.delete {
+		args = append(args, "--delete")
+	}
 	if opts.ModelDir != "" {
 		args = append(args, "--model-dir", containerModelDir)
 	}

--- a/cmd/modelwrap/launcher_test.go
+++ b/cmd/modelwrap/launcher_test.go
@@ -98,3 +98,23 @@ func TestDockerRunArgsPlainMWP(t *testing.T) {
 		t.Fatalf("expected model as final arg: %q", got)
 	}
 }
+
+func TestDockerRunArgsDelete(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("HF_TOKEN", "")
+	t.Setenv("PRIVATE_MODEL_KEY_B64", "")
+	t.Setenv("PRIVATE_MODEL_KEY_FILE", "")
+
+	got, err := dockerRunArgs(cliOptions{
+		Options: wrap.Options{Model: "org/model@rev"},
+		image:   "img",
+		delete:  true,
+	})
+	if err != nil {
+		t.Fatalf("dockerRunArgs: %v", err)
+	}
+	wantTail := []string{"img", "--delete", "org/model@rev"}
+	if !reflect.DeepEqual(got[len(got)-len(wantTail):], wantTail) {
+		t.Fatalf("delete args tail = %q, want %q", got, wantTail)
+	}
+}

--- a/cmd/modelwrap/main.go
+++ b/cmd/modelwrap/main.go
@@ -31,6 +31,7 @@ Run on a host, modelwrap re-executes itself inside the pinned packer
 container image (requires docker). Inside the container it packs directly.
 
 Flags:
+  --delete            delete artifacts and cache for model@revision
   --model-dir <path>  pack a local model directory instead of downloading
   --encrypt           emit encrypted EMWP output (requires a master key)
   --key-file <path>   file containing the base64-encoded 64-byte EMWP master key
@@ -48,8 +49,9 @@ MODELWRAP_IMAGE.`
 // cliOptions extends the packer options with launcher-only settings.
 type cliOptions struct {
 	wrap.Options
-	image string
-	local bool
+	image  string
+	local  bool
+	delete bool
 }
 
 func main() {
@@ -62,6 +64,16 @@ func main() {
 	}
 
 	if opts.local || os.Getenv("MODELWRAP_IN_CONTAINER") == "1" {
+		if opts.delete {
+			if err := wrap.Delete(wrap.DeleteOptions{
+				Model: opts.Model, CacheDir: opts.CacheDir, OutputDir: opts.OutputDir,
+			}); err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err)
+				os.Exit(1)
+			}
+			fmt.Printf("Deleted modelwrap artifacts for %s\n", opts.Model)
+			return
+		}
 		ref, err := wrap.Pack(opts.Options)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
@@ -100,6 +112,7 @@ func parseArgs(args []string) (cliOptions, error) {
 	fs.StringVar(&opts.OutputDir, "output", opts.OutputDir, "")
 	fs.StringVar(&opts.CacheDir, "cache", opts.CacheDir, "")
 	fs.StringVar(&opts.image, "image", opts.image, "")
+	fs.BoolVar(&opts.delete, "delete", false, "")
 	fs.BoolVar(&opts.Verify, "verify", opts.Verify, "")
 	fs.BoolVar(&opts.Encrypt, "encrypt", opts.Encrypt, "")
 	fs.BoolVar(&opts.local, "local", false, "")
@@ -115,6 +128,10 @@ func parseArgs(args []string) (cliOptions, error) {
 	}
 	if len(rest) == 1 {
 		opts.Model = rest[0]
+	}
+	if opts.delete && (opts.ModelDir != "" || opts.Encrypt || opts.Verify || opts.KeyFile != "") {
+		fmt.Fprintln(os.Stderr, "--delete cannot be combined with --model-dir, --encrypt, --verify, or --key-file")
+		return opts, fmt.Errorf("invalid delete options")
 	}
 	return opts, nil
 }

--- a/wrap/delete.go
+++ b/wrap/delete.go
@@ -36,7 +36,7 @@ func Delete(opts DeleteOptions) error {
 	var errs []error
 	for _, suffix := range []string{
 		".mpk", ".info", ".emwp", ".emwp.info",
-		".mpk.tmp", ".info.tmp", ".emwp.tmp", ".emwp.info.tmp",
+		".mpk.tmp", ".info.tmp", ".emwp.tmp", ".emwp.info.tmp", ".emwp.verify.tmp",
 	} {
 		if err := os.Remove(base + suffix); err != nil && !os.IsNotExist(err) {
 			errs = append(errs, fmt.Errorf("removing %s: %w", base+suffix, err))

--- a/wrap/delete.go
+++ b/wrap/delete.go
@@ -1,0 +1,81 @@
+package wrap
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DeleteOptions identifies one pinned model revision and the local modelwrap
+// directories that contain its source cache and generated artifacts.
+type DeleteOptions struct {
+	Model     string
+	CacheDir  string
+	OutputDir string
+}
+
+// Delete removes every generated artifact and the downloaded source cache for
+// one pinned model revision. It is idempotent so callers can safely retry after
+// a partial failure.
+func Delete(opts DeleteOptions) error {
+	modelName, revision, err := splitPinnedModel(opts.Model)
+	if err != nil {
+		return err
+	}
+	if opts.CacheDir == "" {
+		opts.CacheDir = "cache"
+	}
+	if opts.OutputDir == "" {
+		opts.OutputDir = "output"
+	}
+
+	outputModelDir := filepath.Join(opts.OutputDir, filepath.FromSlash(modelName))
+	base := filepath.Join(outputModelDir, revision)
+	var errs []error
+	for _, suffix := range []string{
+		".mpk", ".info", ".emwp", ".emwp.info",
+		".mpk.tmp", ".info.tmp", ".emwp.tmp", ".emwp.info.tmp",
+	} {
+		if err := os.Remove(base + suffix); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("removing %s: %w", base+suffix, err))
+		}
+	}
+
+	cacheRevisionDir := filepath.Join(opts.CacheDir, filepath.FromSlash(modelName), revision)
+	if err := os.RemoveAll(cacheRevisionDir); err != nil {
+		errs = append(errs, fmt.Errorf("removing %s: %w", cacheRevisionDir, err))
+	}
+
+	// Prune only empty parent directories. A non-empty directory simply means
+	// another revision/model still exists and is intentionally retained.
+	pruneEmptyParents(outputModelDir, opts.OutputDir)
+	pruneEmptyParents(filepath.Dir(cacheRevisionDir), opts.CacheDir)
+	return errors.Join(errs...)
+}
+
+func splitPinnedModel(model string) (string, string, error) {
+	name, revision, ok := strings.Cut(model, "@")
+	if !ok || name == "" || revision == "" {
+		return "", "", fmt.Errorf("model must be pinned as model@revision")
+	}
+	if strings.Contains(revision, "/") || strings.Contains(revision, `\`) || revision == "." || revision == ".." {
+		return "", "", fmt.Errorf("invalid model revision %q", revision)
+	}
+	for _, segment := range strings.Split(name, "/") {
+		if segment == "" || segment == "." || segment == ".." || strings.Contains(segment, `\`) {
+			return "", "", fmt.Errorf("invalid model name %q", name)
+		}
+	}
+	return name, revision, nil
+}
+
+func pruneEmptyParents(dir, stop string) {
+	stop = filepath.Clean(stop)
+	for dir = filepath.Clean(dir); dir != stop && dir != "." && dir != string(filepath.Separator); dir = filepath.Dir(dir) {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+	}
+}

--- a/wrap/delete_test.go
+++ b/wrap/delete_test.go
@@ -1,0 +1,74 @@
+package wrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeleteRemovesOnlyPinnedRevision(t *testing.T) {
+	dir := t.TempDir()
+	outputDir := filepath.Join(dir, "output")
+	cacheDir := filepath.Join(dir, "cache")
+	modelDir := filepath.Join(outputDir, "org", "model")
+	cacheModelDir := filepath.Join(cacheDir, "org", "model")
+	for _, path := range []string{
+		filepath.Join(modelDir, "rev1.mpk"),
+		filepath.Join(modelDir, "rev1.info"),
+		filepath.Join(modelDir, "rev1.emwp"),
+		filepath.Join(modelDir, "rev1.emwp.info"),
+		filepath.Join(modelDir, "rev2.mpk"),
+		filepath.Join(cacheModelDir, "rev1", "weights.bin"),
+		filepath.Join(cacheModelDir, "rev2", "weights.bin"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	opts := DeleteOptions{Model: "org/model@rev1", OutputDir: outputDir, CacheDir: cacheDir}
+	if err := Delete(opts); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	// Retrying an already-completed deletion must remain safe.
+	if err := Delete(opts); err != nil {
+		t.Fatalf("Delete retry: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(modelDir, "rev1.mpk"),
+		filepath.Join(modelDir, "rev1.info"),
+		filepath.Join(modelDir, "rev1.emwp"),
+		filepath.Join(modelDir, "rev1.emwp.info"),
+		filepath.Join(cacheModelDir, "rev1"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, got %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(modelDir, "rev2.mpk"),
+		filepath.Join(cacheModelDir, "rev2", "weights.bin"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected sibling revision %s to remain: %v", path, err)
+		}
+	}
+}
+
+func TestDeleteRequiresSafePinnedModel(t *testing.T) {
+	for _, model := range []string{
+		"org/model",
+		"org/model@",
+		"org/model@../revision",
+		"../model@revision",
+		`org\model@revision`,
+	} {
+		if err := Delete(DeleteOptions{Model: model, OutputDir: t.TempDir(), CacheDir: t.TempDir()}); err == nil {
+			t.Errorf("Delete(%q) should fail", model)
+		}
+	}
+}

--- a/wrap/delete_test.go
+++ b/wrap/delete_test.go
@@ -17,6 +17,7 @@ func TestDeleteRemovesOnlyPinnedRevision(t *testing.T) {
 		filepath.Join(modelDir, "rev1.info"),
 		filepath.Join(modelDir, "rev1.emwp"),
 		filepath.Join(modelDir, "rev1.emwp.info"),
+		filepath.Join(modelDir, "rev1.emwp.verify.tmp"),
 		filepath.Join(modelDir, "rev2.mpk"),
 		filepath.Join(cacheModelDir, "rev1", "weights.bin"),
 		filepath.Join(cacheModelDir, "rev2", "weights.bin"),
@@ -43,6 +44,7 @@ func TestDeleteRemovesOnlyPinnedRevision(t *testing.T) {
 		filepath.Join(modelDir, "rev1.info"),
 		filepath.Join(modelDir, "rev1.emwp"),
 		filepath.Join(modelDir, "rev1.emwp.info"),
+		filepath.Join(modelDir, "rev1.emwp.verify.tmp"),
 		filepath.Join(cacheModelDir, "rev1"),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {


### PR DESCRIPTION
Centralizes pinned-revision cleanup in an exported `wrap.Delete` API and the `modelwrap --delete` CLI, removing generated MWP/EMWP outputs and revision caches while retaining sibling revisions; tinfoild consumes this API so artifact naming, path validation, idempotency, and pruning rules have one implementation.