### PR TITLE
fix: revert to erofs-utils 1.5-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,12 @@ ARG DEBIAN_SNAPSHOT=20260518T000000Z
 RUN printf '%s\n' \
     "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ trixie main" \
     "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ trixie-security main" \
+    "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm main" \
     > /etc/apt/sources.list && \
     rm -f /etc/apt/sources.list.d/*.sources && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        erofs-utils=1.8.6-1 \
+        erofs-utils=1.5-1 \
         cryptsetup=2:2.7.5-2 \
         gdisk=1.0.10-2 && \
     rm -rf /var/lib/apt/lists/*

--- a/integration_test.go
+++ b/integration_test.go
@@ -23,6 +23,12 @@ const (
 	integrationModelName     = "hf-internal-testing/tiny-random-GPT2Model"
 	integrationModelRevision = "d6694b0d8fe17978761c9305dc151780506b192e"
 	integrationModel         = integrationModelName + "@" + integrationModelRevision
+
+	// integrationExpectedRef pins the full packed ref
+	// (rootHash_hashOffset_uuid) for integrationModel. If such a change is
+	// intentional, update this constant and treat it as a breaking change for
+	// every already-enrolled artifact hash.
+	integrationExpectedRef = "17c6605f3becf63a63da37cc6958b2d18f8abc750f9f546b9f57133db40c4326_2142208_9701bf21-6de2-59a2-bdea-141aaae05fc3"
 )
 
 // TestEMWPRoundTripIntegration downloads and packs a tiny public model as
@@ -60,6 +66,13 @@ func TestEMWPRoundTripIntegration(t *testing.T) {
 	}
 	if want := modelwrap.UUIDv5URL(integrationModel + "-emwp-outer"); ref.UUID != want {
 		t.Fatalf("EMWP PARTUUID = %s, want %s", ref.UUID, want)
+	}
+	// Check that the generated ref is still stable. If the ref changes, then
+	// the new version should be considered a breaking change.
+	if rawRef != integrationExpectedRef {
+		t.Fatalf("packed ref = %s, want %s\n"+
+			"The generated artifact changed. If a packer toolchain change was intentional, "+
+			"update integrationExpectedRef; otherwise find what changed in the container image.", rawRef, integrationExpectedRef)
 	}
 
 	emwpFile := filepath.Join(work, "output", integrationModelName, integrationModelRevision+".emwp")


### PR DESCRIPTION
Commit 459450934c35f4bd0b149c198515977bfb807e2e hardens the supply chain by pinning all the dependencies, but in the process, updated erofs-utils from 1.5-1 to 1.8.6-1 as part of updating from the debian:bookworm image to debian:trixie. This changed the generated erofs image which changes the dmverity root hash, leading to a breaking change in newer versions of modelwrap. This commit reverts to the old erofs-utils until we can find a better way to stabilize the generated erofs image.

Validated this change by testing the generated hash on a test model:
```console
# Before applying this patch
$ make build
$ sudo make pack hf-internal-testing/tiny-random-GPT2Model@d6694b0d8fe17978761c9305dc151780506b192e
...
e08ac80979ec407733e9958f6aefb4ccd015c79233ac62155d79db10b4ae1fd4_2142208_905785b4-b198-5ed6-b97d-e7c36a0be1df

# Clear the cache
$ sudo rm -r output/hf-internal-testing/tiny-random-GPT2Model/d6694b0d8fe17978761c9305dc151780506b192e.*

# After applying this patch
$ make build
$ sudo make pack hf-internal-testing/tiny-random-GPT2Model@d6694b0d8fe17978761c9305dc151780506b192e
...
17c6605f3becf63a63da37cc6958b2d18f8abc750f9f546b9f57133db40c4326_2142208_905785b4-b198-5ed6-b97d-e7c36a0be1df
# This hash matches what is generated prior to 459450934c35f4bd0b149c198515977bfb807e2e
```